### PR TITLE
Add setting to show/hide workspace names

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Select an icon and click "Copy Unicode Glyph".
 
 If you can't see any icons make sure Font Awesome is installed as "Font Awesome 5 Free Solid". Try running `fc-match "Font Awesome 5 Free Solid"` and see if you get a match.
 
+You can choose to hide workspace names in the plasmoid settings.
+
 ## Multiple monitors
 
 If you use multiple monitors you need to add the plasmoid to each monitor as the plasmoid only shows workspaces for the monitor it is active on. This is a personal preference and I'm open to adding an option to show all workspaces regardless of monitor.

--- a/plasmoid/contents/config/config.qml
+++ b/plasmoid/contents/config/config.qml
@@ -1,0 +1,10 @@
+import QtQuick 2.0
+import org.kde.plasma.configuration 2.0
+
+ConfigModel {
+    ConfigCategory {
+        name: i18n("General")
+        icon: "configure"
+        source: "configGeneral.qml"
+    }
+}

--- a/plasmoid/contents/config/main.xml
+++ b/plasmoid/contents/config/main.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kcfg xmlns="http://www.kde.org/standards/kcfg/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.kde.org/standards/kcfg/1.0 http://www.kde.org/standards/kcfg/1.0/kcfg.xsd">
+    <kcfgfile name=""/>
+    <group name="General">
+        <entry name="showWorkspaceNames" type="Bool">
+            <default>true</default>
+        </entry>
+    </group>
+</kcfg>

--- a/plasmoid/contents/ui/configGeneral.qml
+++ b/plasmoid/contents/ui/configGeneral.qml
@@ -1,0 +1,19 @@
+import QtQuick 2.0
+import QtQuick.Controls 2.5
+import QtQuick.Layouts 1.12
+import org.kde.kirigami 2.4 as Kirigami
+
+Item {
+    id: page
+    width: childrenRect.width
+    height: childrenRect.height
+
+    property alias cfg_showWorkspaceNames: showWorkspaceNames.checked
+
+    CheckBox {
+        id: showWorkspaceNames
+        text: i18n("Show workspace names")
+        checked: plasmoid.configuration.showWorkspaceNames
+        onCheckedChanged: plasmoid.configuration.showWorkspaceNames = checked
+    }
+}

--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -69,8 +69,11 @@ ColumnLayout {
                 RowLayout {
                     id: textRow
                     height: parent.height
+                    
+                    Rectangle {
+                        width: 5
+                    }
                     Text {
-                        leftPadding: 10
                         font.family: "Noto Sans"
                         height: textRow.height
                         minimumPixelSize: 10
@@ -94,9 +97,9 @@ ColumnLayout {
                         color: "#dfdfdf"
                         text: modelData.icon
                         verticalAlignment: Text.AlignHCenter
+                        visible: plasmoid.configuration.showWorkspaceNames
                     }
                     Text {
-                        rightPadding: 10
                         height: textRow.height
                         minimumPixelSize: 10
                         font.pixelSize: 15
@@ -105,6 +108,10 @@ ColumnLayout {
                         color: "#dfdfdf"
                         text: modelData.name
                         verticalAlignment: Text.AlignHCenter
+                        visible: plasmoid.configuration.showWorkspaceNames
+                    }
+                    Rectangle {
+                        width: 5
                     }
                 }
             }


### PR DESCRIPTION
This pull request adds the option to show or hide workspace names in the widget. The default is to show workspace names.