### PR TITLE
Fix problem with running plasmoid in plasmas native X11 enviroment

### DIFF
--- a/src/i3listener.cpp
+++ b/src/i3listener.cpp
@@ -38,6 +38,7 @@ void I3ListenerThread::handleI3Events() {
         }
     } catch (std::exception const& e) {
         qWarning() << "Exception in i3listener handle events:" << e.what();
+        this->stop();
     }
 }
 


### PR DESCRIPTION
Hello.

I stumbled upon a problem with my KDE Plasma/I3 setup, when I tried to log into a session using the original X11 enviroment after installing i3-pager. This caused the whole login procedure to crash, which was a bit of a problem. I figured out that the problem laid in i3ipcpp and not this plugin. I made a fix for it and made a [pull request to i3ipcpp](https://github.com/drmgc/i3ipcpp/pull/39).

This fix results in some other problems in the i3-pager plasmoid though. As the fix got everything running as it should, multiple calls to open files started to be made even though all calls failed (as I was using the wrong window manager). This eventually resulted in no more file calls to be accepted from any plasma process, crashing the whole desktop enviroment.

I fixed this by making the plasmoid stop if it didn't succeed with the calls. I have tested it in both window managers and it doesn't seem to break anything.

I would appreciate if you would like to consider my pull request. Thanks in advance.